### PR TITLE
Support Struct Data Types and arrays

### DIFF
--- a/plugins/datastreamer_plugin/fastdds/Participant.cpp
+++ b/plugins/datastreamer_plugin/fastdds/Participant.cpp
@@ -271,13 +271,24 @@ void Participant::on_type_discovery(
 
     DEBUG("TypeObject discovered: " << dyn_type->get_name() << " for topic: " << topic.to_string());
 
-    // Create TypeSupport and register it in Participant
-    eprosima::fastdds::dds::TypeSupport(
-        new eprosima::fastrtps::types::DynamicPubSubType(dyn_type)).register_type(participant_);
+    // TOOD study this
+    // In case of complex data types, registering here means that the data type will be incorrectly registered
+    // because the internal data will be received and registered faster than lookup service, which produces an error
+    // when registering type:
+    //  logError(PARTICIPANT, "Another type with the same name Struct_TypeIntrospectionExample is already registered.");
+    // WORKAROUND: only use TypeLookup service to get Type Information and forget about the TypeObject
+    // For the future: it seems like the error appears when registering the type from here because this callback is
+    // erroneous, so it can be checked wether this type has already been registered. Be careful because it should
+    // not only check it has been registered but it has been discovered by the Service, that may be in process of
+    // registering when this callback arrives
 
-    // In case this callback is sent, it means that the type is already registered, so notify
-    // TODO in future it would be better to update every topic in this type name, and not just the one calling here
-    on_topic_discovery_(topic.to_string(), dyn_type->get_name());
+    // Create TypeSupport and register it
+    // eprosima::fastdds::dds::TypeSupport(
+    //     new eprosima::fastrtps::types::DynamicPubSubType(dyn_type)).register_type(participant_);
+
+    // // In case this callback is sent, it means that the type is already registered, so notify
+    // // TODO in future it would be better to update every topic in this type name, and not just the one calling here
+    // on_topic_discovery_(topic.to_string(), dyn_type->get_name());
 }
 
 ////////////////////////////////////////////////////

--- a/plugins/datastreamer_plugin/fastdds/Participant.cpp
+++ b/plugins/datastreamer_plugin/fastdds/Participant.cpp
@@ -230,7 +230,7 @@ void Participant::on_publisher_discovery(
 }
 
 void Participant::on_type_information_received(
-        eprosima::fastdds::dds::DomainParticipant* participant,
+        eprosima::fastdds::dds::DomainParticipant*,
         const fastrtps::string_255 topic_name,
         const fastrtps::string_255 type_name,
         const fastrtps::types::TypeInformation& type_information)
@@ -242,11 +242,12 @@ void Participant::on_type_information_received(
         [this, topic_name]
             (const std::string&, const eprosima::fastrtps::types::DynamicType_ptr type)
         {
-            // Once the type has been registered, call on_topic_discovery_ so the callback is sent if it must
+            DEBUG(
+                "Type discovered by lookup info: " << type->get_name() << " in topic: " << topic_name.to_string());
             this->on_topic_discovery_(topic_name.to_string(), type->get_name());
         });
 
-    // Register participant
+    // Registering type and creating reader
     participant_->register_remote_type(
         type_information,
         type_name.to_string(),

--- a/plugins/datastreamer_plugin/fastdds/ReaderHandler.cpp
+++ b/plugins/datastreamer_plugin/fastdds/ReaderHandler.cpp
@@ -124,12 +124,13 @@ void ReaderHandler::on_data_available(
             double timestamp = utils::get_timestamp_seconds_numeric_value(info.reception_timestamp);
 
             // Get data in already created structures
-            utils::get_introspection_data(
-                type_,
+            utils::get_introspection_numeric_data(
                 numeric_data_info_,
+                data_,
+                numeric_data_);
+            utils::get_introspection_string_data(
                 string_data_info_,
                 data_,
-                numeric_data_,
                 string_data_);
 
             // Get value maps from data and send callback if there are data

--- a/plugins/datastreamer_plugin/fastdds/ReaderHandler.hpp
+++ b/plugins/datastreamer_plugin/fastdds/ReaderHandler.hpp
@@ -133,8 +133,8 @@ public:
     utils::TypeIntrospectionCollection numeric_data_info_;
     utils::TypeIntrospectionCollection string_data_info_;
 
-    utils::TypeIntrospectionNumericDatum numeric_data_;
-    utils::TypeIntrospectionStringDatum string_data_;
+    utils::TypeIntrospectionNumericStruct numeric_data_;
+    utils::TypeIntrospectionStringStruct string_data_;
 
 };
 

--- a/plugins/datastreamer_plugin/utils/dynamic_types_utils.cpp
+++ b/plugins/datastreamer_plugin/utils/dynamic_types_utils.cpp
@@ -64,32 +64,32 @@ void get_introspection_type_names(
 
     switch(kind)
     {
-        case TK_BOOLEAN:
-        case TK_BYTE:
-        case TK_INT16:
-        case TK_INT32:
-        case TK_INT64:
-        case TK_UINT16:
-        case TK_UINT32:
-        case TK_UINT64:
-        case TK_FLOAT32:
-        case TK_FLOAT64:
-        case TK_FLOAT128:
+        case fastrtps::types::TK_BOOLEAN:
+        case fastrtps::types::TK_BYTE:
+        case fastrtps::types::TK_INT16:
+        case fastrtps::types::TK_INT32:
+        case fastrtps::types::TK_INT64:
+        case fastrtps::types::TK_UINT16:
+        case fastrtps::types::TK_UINT32:
+        case fastrtps::types::TK_UINT64:
+        case fastrtps::types::TK_FLOAT32:
+        case fastrtps::types::TK_FLOAT64:
+        case fastrtps::types::TK_FLOAT128:
             // Add numeric value
             numeric_type_names.push_back(
                 {base_type_name, current_members_tree, current_kinds_tree, kind});
             break;
 
-        case TK_CHAR8:
-        case TK_CHAR16:
-        case TK_STRING8:
-        case TK_STRING16:
-        case TK_ENUM:
+        case fastrtps::types::TK_CHAR8:
+        case fastrtps::types::TK_CHAR16:
+        case fastrtps::types::TK_STRING8:
+        case fastrtps::types::TK_STRING16:
+        case fastrtps::types::TK_ENUM:
             string_type_names.push_back(
                 {base_type_name, current_members_tree, current_kinds_tree, kind});
             break;
 
-        case TK_ARRAY:
+        case fastrtps::types::TK_ARRAY:
         {
             DynamicType_ptr internal_type =
                 array_internal_kind(type);
@@ -114,7 +114,7 @@ void get_introspection_type_names(
             break;
         }
 
-        case TK_STRUCTURE:
+        case fastrtps::types::TK_STRUCTURE:
         {
             // Using the Dynamic type, retrieve the name of the fields and its descriptions
             std::map<std::string, DynamicTypeMember*> members_by_name;
@@ -122,7 +122,7 @@ void get_introspection_type_names(
 
             DEBUG("Size of members " << members_by_name.size());
 
-            for (auto& members : members_by_name)
+            for (const auto& members : members_by_name)
             {
                 DEBUG("Calling introspection for " << members.first);
 
@@ -143,11 +143,11 @@ void get_introspection_type_names(
             break;
         }
 
-        case TK_BITSET:
-        case TK_UNION:
-        case TK_SEQUENCE:
-        case TK_MAP:
-        case TK_NONE:
+        case fastrtps::types::TK_BITSET:
+        case fastrtps::types::TK_UNION:
+        case fastrtps::types::TK_SEQUENCE:
+        case fastrtps::types::TK_MAP:
+        case fastrtps::types::TK_NONE:
         default:
             WARNING(kind << " DataKind Not supported");
             throw std::runtime_error("Unsupported Dynamic Types kind");
@@ -161,6 +161,10 @@ void get_introspection_numeric_data(
 {
     DEBUG("Getting numeric data");
 
+    if (numeric_type_names.size() != numeric_data_result.size()) {
+        throw InconsistencyException("Vector of struct and result sizes mismatch in get_introspection_numeric_data");
+    }
+
     // It is used by index of the vector to avoid unnecessary lookups.
     // Vectors must be sorted in the same order => creation order given in get_introspection_type_names
     for (int i = 0; i < numeric_type_names.size(); ++i)
@@ -168,9 +172,9 @@ void get_introspection_numeric_data(
         const auto& member_type_info = numeric_type_names[i];
 
         // Get reference to variables to avoid calling get twice
-        const std::vector<MemberId>& members =
+        const auto& members =
             std::get<std::vector<MemberId>>(member_type_info);
-        const std::vector<TypeKind>& kinds =
+        const auto& kinds =
             std::get<std::vector<TypeKind>>(member_type_info);
 
         const TypeKind& actual_kind =
@@ -196,6 +200,10 @@ void get_introspection_string_data(
 {
     DEBUG("Getting string data");
 
+    if (string_type_names.size() != string_data_result.size()) {
+        throw InconsistencyException("Vector of struct and result sizes mismatch in get_introspection_string_data");
+    }
+
     // It is used by index of the vector to avoid unnecessary lookups.
     // Vectors must be sorted in the same order => creation order given in get_introspection_type_names
     for (int i = 0; i < string_type_names.size(); ++i)
@@ -203,9 +211,9 @@ void get_introspection_string_data(
         const auto& member_type_info = string_type_names[i];
 
         // Get reference to variables to avoid calling get twice
-        const std::vector<MemberId>& members =
+        const auto& members =
             std::get<std::vector<MemberId>>(member_type_info);
-        const std::vector<TypeKind>& kinds =
+        const auto& kinds =
             std::get<std::vector<TypeKind>>(member_type_info);
 
         const TypeKind& actual_kind =
@@ -244,7 +252,7 @@ DynamicData_ptr get_parent_data_of_member(
 
         switch (kind)
         {
-        case TK_STRUCTURE:
+        case fastrtps::types::TK_STRUCTURE:
         {
             // Access to the data inside the structure
             DynamicData* child_data;
@@ -256,7 +264,7 @@ DynamicData_ptr get_parent_data_of_member(
                 kind_tree,
                 array_indexes + 1);
         }
-        case TK_ARRAY:
+        case fastrtps::types::TK_ARRAY:
         {
             // TODO (this is not so important as a type with a complex array will die before
             // arriving here)
@@ -280,37 +288,37 @@ double get_numeric_type_from_data(
 
     switch (kind)
     {
-        case TK_BOOLEAN:
+        case fastrtps::types::TK_BOOLEAN:
             return static_cast<double>(data->get_bool_value(member));
 
-        case TK_BYTE:
+        case fastrtps::types::TK_BYTE:
             return static_cast<double>(data->get_byte_value(member));
 
-        case TK_INT16:
+        case fastrtps::types::TK_INT16:
             return static_cast<double>(data->get_int16_value(member));
 
-        case TK_INT32:
+        case fastrtps::types::TK_INT32:
             return static_cast<double>(data->get_int32_value(member));
 
-        case TK_INT64:
+        case fastrtps::types::TK_INT64:
             return static_cast<double>(data->get_int64_value(member));
 
-        case TK_UINT16:
+        case fastrtps::types::TK_UINT16:
             return static_cast<double>(data->get_uint16_value(member));
 
-        case TK_UINT32:
+        case fastrtps::types::TK_UINT32:
             return static_cast<double>(data->get_uint32_value(member));
 
-        case TK_UINT64:
+        case fastrtps::types::TK_UINT64:
             return static_cast<double>(data->get_uint64_value(member));
 
-        case TK_FLOAT32:
+        case fastrtps::types::TK_FLOAT32:
             return static_cast<double>(data->get_float32_value(member));
 
-        case TK_FLOAT64:
+        case fastrtps::types::TK_FLOAT64:
             return static_cast<double>(data->get_float64_value(member));
 
-        case TK_FLOAT128:
+        case fastrtps::types::TK_FLOAT128:
             return static_cast<double>(data->get_float128_value(member));
 
         default:
@@ -327,19 +335,19 @@ std::string get_string_type_from_data(
     DEBUG("Getting string data of kind " << kind << " in member " << member);
     switch (kind)
     {
-        case TK_CHAR8:
+        case fastrtps::types::TK_CHAR8:
             return to_string(data->get_char8_value(member));
 
-        case TK_CHAR16:
+        case fastrtps::types::TK_CHAR16:
             return to_string(data->get_char16_value(member));
 
-        case TK_STRING8:
+        case fastrtps::types::TK_STRING8:
             return data->get_string_value(member);
 
-        case TK_STRING16:
+        case fastrtps::types::TK_STRING16:
             return to_string(data->get_wstring_value(member));
 
-        case TK_ENUM:
+        case fastrtps::types::TK_ENUM:
             return data->get_enum_value(member);
 
         default:
@@ -354,17 +362,17 @@ bool is_kind_numeric(
 {
     switch (kind)
     {
-        case TK_BOOLEAN:
-        case TK_BYTE:
-        case TK_INT16:
-        case TK_INT32:
-        case TK_INT64:
-        case TK_UINT16:
-        case TK_UINT32:
-        case TK_UINT64:
-        case TK_FLOAT32:
-        case TK_FLOAT64:
-        case TK_FLOAT128:
+        case fastrtps::types::TK_BOOLEAN:
+        case fastrtps::types::TK_BYTE:
+        case fastrtps::types::TK_INT16:
+        case fastrtps::types::TK_INT32:
+        case fastrtps::types::TK_INT64:
+        case fastrtps::types::TK_UINT16:
+        case fastrtps::types::TK_UINT32:
+        case fastrtps::types::TK_UINT64:
+        case fastrtps::types::TK_FLOAT32:
+        case fastrtps::types::TK_FLOAT64:
+        case fastrtps::types::TK_FLOAT128:
             return true;
 
         default:
@@ -377,11 +385,11 @@ bool is_kind_string(
 {
     switch (kind)
     {
-        case TK_CHAR8:
-        case TK_CHAR16:
-        case TK_STRING8:
-        case TK_STRING16:
-        case TK_ENUM:
+        case fastrtps::types::TK_CHAR8:
+        case fastrtps::types::TK_CHAR16:
+        case fastrtps::types::TK_STRING8:
+        case fastrtps::types::TK_STRING16:
+        case fastrtps::types::TK_ENUM:
             return true;
 
         default:

--- a/plugins/datastreamer_plugin/utils/dynamic_types_utils.cpp
+++ b/plugins/datastreamer_plugin/utils/dynamic_types_utils.cpp
@@ -62,7 +62,7 @@ void get_introspection_type_names(
     // Get type kind and store it as kind tree
     TypeKind kind = type->get_kind();
 
-    switch(kind)
+    switch (kind)
     {
         case fastrtps::types::TK_BOOLEAN:
         case fastrtps::types::TK_BYTE:
@@ -92,7 +92,7 @@ void get_introspection_type_names(
         case fastrtps::types::TK_ARRAY:
         {
             DynamicType_ptr internal_type =
-                array_internal_kind(type);
+                    array_internal_kind(type);
             unsigned int this_array_size = array_size(type);
 
             for (unsigned int i = 0; i < this_array_size; i++)
@@ -161,7 +161,8 @@ void get_introspection_numeric_data(
 {
     DEBUG("Getting numeric data");
 
-    if (numeric_type_names.size() != numeric_data_result.size()) {
+    if (numeric_type_names.size() != numeric_data_result.size())
+    {
         throw InconsistencyException("Vector of struct and result sizes mismatch in get_introspection_numeric_data");
     }
 
@@ -173,12 +174,12 @@ void get_introspection_numeric_data(
 
         // Get reference to variables to avoid calling get twice
         const auto& members =
-            std::get<std::vector<MemberId>>(member_type_info);
+                std::get<std::vector<MemberId>>(member_type_info);
         const auto& kinds =
-            std::get<std::vector<TypeKind>>(member_type_info);
+                std::get<std::vector<TypeKind>>(member_type_info);
 
         const TypeKind& actual_kind =
-            std::get<TypeKind>(member_type_info);
+                std::get<TypeKind>(member_type_info);
 
         // Get Data parent that has the member we are looking for
         const auto& parent_data = get_parent_data_of_member(
@@ -200,7 +201,8 @@ void get_introspection_string_data(
 {
     DEBUG("Getting string data");
 
-    if (string_type_names.size() != string_data_result.size()) {
+    if (string_type_names.size() != string_data_result.size())
+    {
         throw InconsistencyException("Vector of struct and result sizes mismatch in get_introspection_string_data");
     }
 
@@ -212,12 +214,12 @@ void get_introspection_string_data(
 
         // Get reference to variables to avoid calling get twice
         const auto& members =
-            std::get<std::vector<MemberId>>(member_type_info);
+                std::get<std::vector<MemberId>>(member_type_info);
         const auto& kinds =
-            std::get<std::vector<TypeKind>>(member_type_info);
+                std::get<std::vector<TypeKind>>(member_type_info);
 
         const TypeKind& actual_kind =
-            std::get<TypeKind>(member_type_info);
+                std::get<TypeKind>(member_type_info);
 
         // Get Data parent that has the member we are looking for
         const auto& parent_data = get_parent_data_of_member(
@@ -252,29 +254,29 @@ DynamicData_ptr get_parent_data_of_member(
 
         switch (kind)
         {
-        case fastrtps::types::TK_STRUCTURE:
-        {
-            // Access to the data inside the structure
-            DynamicData* child_data;
-            data->get_complex_value(&child_data, member_id);
+            case fastrtps::types::TK_STRUCTURE:
+            {
+                // Access to the data inside the structure
+                DynamicData* child_data;
+                data->get_complex_value(&child_data, member_id);
 
-            return get_parent_data_of_member(
-                DynamicData_ptr(child_data),
-                members_tree,
-                kind_tree,
-                array_indexes + 1);
-        }
-        case fastrtps::types::TK_ARRAY:
-        {
-            // TODO (this is not so important as a type with a complex array will die before
-            // arriving here)
-        }
+                return get_parent_data_of_member(
+                    DynamicData_ptr(child_data),
+                    members_tree,
+                    kind_tree,
+                    array_indexes + 1);
+            }
+            case fastrtps::types::TK_ARRAY:
+            {
+                // TODO (this is not so important as a type with a complex array will die before
+                // arriving here)
+            }
             // TODO
-        default:
-            // TODO add exception
-            WARNING("Error getting data");
-            return data;
-            break;
+            default:
+                // TODO add exception
+                WARNING("Error getting data");
+                return data;
+                break;
         }
     }
 }
@@ -355,7 +357,6 @@ std::string get_string_type_from_data(
             throw InconsistencyException("Member wrongly set as string");
     }
 }
-
 
 bool is_kind_numeric(
         const TypeKind& kind)

--- a/plugins/datastreamer_plugin/utils/dynamic_types_utils.hpp
+++ b/plugins/datastreamer_plugin/utils/dynamic_types_utils.hpp
@@ -29,44 +29,152 @@ namespace eprosima {
 namespace plotjuggler {
 namespace utils {
 
+using namespace eprosima::fastrtps::types;
+
 using SingleDataTypeIntrospectionInfo =
         std::tuple<
-    types::DatumLabel,
-    eprosima::fastrtps::types::MemberId,
-    eprosima::fastrtps::types::TypeKind>;
+            types::DatumLabel,
+            std::vector<MemberId>,   // Member Ids of the parents of the data member
+            std::vector<TypeKind>,   // Kind of the parents of the data member
+            TypeKind>;               // Kind of this member
+
 using TypeIntrospectionCollection =
         std::vector<SingleDataTypeIntrospectionInfo>;
 
-using TypeIntrospectionNumericDatum = std::vector<types::NumericDatum>;
-using TypeIntrospectionStringDatum = std::vector<types::TextDatum>;
+using TypeIntrospectionNumericStruct = std::vector<types::NumericDatum>;
+using TypeIntrospectionStringStruct = std::vector<types::TextDatum>;
 
+/**
+ * @brief Get the names of each label in a \c TypeIntrospectionCollection
+ * This function is used to obtain all the labels form by topics + data type members
+ *
+ * Iterate over every \c SingleDataTypeIntrospectionInfo and get the \c DatumLabel .
+ *
+ * @param numeric_type_names collection to get all names
+ * @return all label names
+ */
 std::vector<std::string> get_introspection_type_names(
         const TypeIntrospectionCollection& numeric_type_names);
 
+/**
+ * @brief Get the introspection information from a \c DynamicType_ptr
+ * This is a recursive function that may be called recursively for each data type member
+ * of \c type .
+ *
+ * If \c type is a basic type, it adds its label, that is \c base_type_name to the
+ * \c TypeIntrospectionCollection that it belongs, depending if it is numeric or text kind.
+ * Along with the label, it is added the vector of parents as member Ids and kinds.
+ * Those are useful to allow to acces this specific field from a \c DynamicData_ptr .
+ *
+ * If \c type is not a basic type (array or struct) this function is called for each value
+ * updating \c base_type_name for each recursive call.
+ *
+ * \c current_members_tree and \c current_kinds_tree are used to store the parent information
+ * for every recursive iteration of the function.
+ *
+ * @param base_type_name [in]
+ * @param type [in]
+ * @param numeric_type_names [out]
+ * @param string_type_names [out]
+ * @param current_members_tree [in]
+ * @param current_kinds_tree [in]
+ * @param separator [in]
+ */
 void get_introspection_type_names(
         const std::string& base_type_name,
-        eprosima::fastrtps::types::DynamicType_ptr type,
+        const DynamicType_ptr& type,
         TypeIntrospectionCollection& numeric_type_names,
         TypeIntrospectionCollection& string_type_names,
+        const std::vector<MemberId>& current_members_tree = {},
+        const std::vector<TypeKind>& current_kinds_tree = {},
         const std::string& separator = "/");
 
-void get_introspection_data(
-        eprosima::fastrtps::types::DynamicType_ptr type,
+/**
+ * @brief Fill numeric and string data from a \c data given
+ *
+ * This method uses the already calculated \c SingleDataTypeIntrospectionInfo objects
+ * to make data introspection faster, by access directly the members required (to access those members
+ * it is needed the kind of each, that is why it is stored).
+ *
+ * The data found along the data is stored in object \c numeric_data .
+ * This object is already created and populated with the labels, and it is accessed by
+ * the same index in \c numeric_type_names .
+ * This way, we avoid creating and copying the strings each time a data arrive.
+ * Instead, we reuse the whole structure with labels, and with each data is populated with the new data recieved.
+ *
+ * @param numeric_type_names [in]
+ * @param data [in]
+ * @param numeric_data [in|out]
+ */
+void get_introspection_numeric_data(
         const TypeIntrospectionCollection& numeric_type_names,
+        const DynamicData_ptr& data,
+        TypeIntrospectionNumericStruct& numeric_data_result);
+
+/**
+ * @brief TODO
+ */
+void get_introspection_string_data(
         const TypeIntrospectionCollection& string_type_names,
-        eprosima::fastrtps::types::DynamicData_ptr data,
-        TypeIntrospectionNumericDatum& numeric_data,
-        TypeIntrospectionStringDatum& string_data);
+        const DynamicData_ptr& data,
+        TypeIntrospectionStringStruct& string_data_result);
 
+/**
+ * @brief Get the parent data from a \c data given following the chaing of
+ * parents given their parent \c members and \c kinds .
+ *
+ * This recursive function calls recursively to itself with the next data member of
+ * \c data following the member and kind indicated by \c array_index , that changes in every iteration
+ *
+ * @param data [in]
+ * @param members_tree [in]
+ * @param kind [in]
+ * @param array_indexes [in]
+ * @return DynamicData_ptr
+ */
+DynamicData_ptr get_parent_data_of_member(
+        const DynamicData_ptr& data,
+        const std::vector<MemberId>& members,
+        const std::vector<TypeKind>& kinds,
+        unsigned int array_index = 0);
+
+/**
+ * @brief Get the numeric value of the data member of \c data given and with \c member id and \c kind given
+ *
+ * @param data [in]
+ * @param member [in]
+ * @param kind [in]
+ * @return numeric data of the member casted to double
+ */
 double get_numeric_type_from_data(
-        eprosima::fastrtps::types::DynamicData_ptr data,
-        eprosima::fastrtps::types::MemberId member,
-        eprosima::fastrtps::types::TypeKind kind);
+        const DynamicData_ptr& data,
+        const MemberId& member,
+        const TypeKind& kind);
 
+/**
+ * @brief Get the string value of the data member of \c data given and with \c member id and \c kind given
+ *
+ * @param data [in]
+ * @param member [in]
+ * @param kind [in]
+ * @return string data of the member casted to string
+ */
 std::string get_string_type_from_data(
-        eprosima::fastrtps::types::DynamicData_ptr data,
-        eprosima::fastrtps::types::MemberId member,
-        eprosima::fastrtps::types::TypeKind kind);
+        const DynamicData_ptr& data,
+        const MemberId& member,
+        const TypeKind& kind);
+
+bool is_kind_numeric(
+        const TypeKind& kind);
+
+bool is_kind_string(
+        const TypeKind& kind);
+
+DynamicType_ptr array_internal_kind(
+        const DynamicType_ptr& dyn_type);
+
+unsigned int array_size(
+        const DynamicType_ptr& dyn_type);
 
 } /* namespace utils */
 } /* namespace plotjuggler */

--- a/plugins/datastreamer_plugin/utils/dynamic_types_utils.hpp
+++ b/plugins/datastreamer_plugin/utils/dynamic_types_utils.hpp
@@ -33,10 +33,10 @@ using namespace eprosima::fastrtps::types;
 
 using SingleDataTypeIntrospectionInfo =
         std::tuple<
-            types::DatumLabel,
-            std::vector<MemberId>,   // Member Ids of the parents of the data member
-            std::vector<TypeKind>,   // Kind of the parents of the data member
-            TypeKind>;               // Kind of this member
+    types::DatumLabel,
+    std::vector<MemberId>,           // Member Ids of the parents of the data member
+    std::vector<TypeKind>,           // Kind of the parents of the data member
+    TypeKind>;                       // Kind of this member
 
 using TypeIntrospectionCollection =
         std::vector<SingleDataTypeIntrospectionInfo>;


### PR DESCRIPTION
Merge after
- #1 
- #8 
- #9 

Support new Data Type types:
- Structs with internal structs
- Arrays of basic types

It does not support the following:
- DynamicType discovery by TypeObject (it raises an error in callback `on_type_discovery` and the data is incorrectly registered
- Array of struct data types (this produces a seg fault in Fast DDS Dynamic Types).