### PR TITLE
Removed utilization of DynamicData_ptr

### DIFF
--- a/plugins/datastreamer_plugin/fastdds/ReaderHandler.hpp
+++ b/plugins/datastreamer_plugin/fastdds/ReaderHandler.hpp
@@ -23,6 +23,7 @@
 #define _EPROSIMA_PLOTJUGGLERFASTDDSPLUGIN_PLUGINS_DATASTREAMERPLUGIN_FASTDDS_READERHANDLER_HPP_
 
 #include <atomic>
+#include <mutex>
 
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/subscriber/DataReader.hpp>
@@ -128,7 +129,7 @@ public:
     eprosima::fastrtps::types::DynamicType_ptr type_;
 
     //! Data Type element
-    eprosima::fastrtps::types::DynamicData_ptr data_;
+    eprosima::fastrtps::types::DynamicData* data_;
 
     std::atomic<bool> stop_;
 
@@ -137,6 +138,8 @@ public:
 
     utils::TypeIntrospectionNumericStruct numeric_data_;
     utils::TypeIntrospectionStringStruct string_data_;
+
+    std::mutex mtx_data_available_;
 
 };
 

--- a/plugins/datastreamer_plugin/utils/dynamic_types_utils.cpp
+++ b/plugins/datastreamer_plugin/utils/dynamic_types_utils.cpp
@@ -58,10 +58,10 @@ void get_introspection_type_names(
         const std::vector<TypeKind>& current_kinds_tree /* = {} */,
         const std::string& separator /* = "/" */)
 {
-    DEBUG("Getting types for type member " << base_type_name);
-
     // Get type kind and store it as kind tree
     TypeKind kind = type->get_kind();
+
+    DEBUG("Getting types for type member " << base_type_name << " of kind " + std::to_string(kind));
 
     switch (kind)
     {
@@ -180,7 +180,7 @@ void get_introspection_type_names(
 
 void get_introspection_numeric_data(
         const TypeIntrospectionCollection& numeric_type_names,
-        const DynamicData_ptr& data,
+        DynamicData* data,
         TypeIntrospectionNumericStruct& numeric_data_result)
 {
     DEBUG("Getting numeric data");
@@ -206,7 +206,7 @@ void get_introspection_numeric_data(
                 std::get<TypeKind>(member_type_info);
 
         // Get Data parent that has the member we are looking for
-        const auto& parent_data = get_parent_data_of_member(
+        auto parent_data = get_parent_data_of_member(
             data,
             members,
             kinds);
@@ -220,7 +220,7 @@ void get_introspection_numeric_data(
 
 void get_introspection_string_data(
         const TypeIntrospectionCollection& string_type_names,
-        const eprosima::fastrtps::types::DynamicData_ptr& data,
+        DynamicData* data,
         TypeIntrospectionStringStruct& string_data_result)
 {
     DEBUG("Getting string data");
@@ -246,7 +246,7 @@ void get_introspection_string_data(
                 std::get<TypeKind>(member_type_info);
 
         // Get Data parent that has the member we are looking for
-        const auto& parent_data = get_parent_data_of_member(
+        auto parent_data = get_parent_data_of_member(
             data,
             members,
             kinds);
@@ -258,12 +258,14 @@ void get_introspection_string_data(
     }
 }
 
-DynamicData_ptr get_parent_data_of_member(
-        const DynamicData_ptr& data,
+DynamicData* get_parent_data_of_member(
+        DynamicData* data,
         const std::vector<MemberId>& members_tree,
         const std::vector<TypeKind>& kind_tree,
         unsigned int array_indexes /* = 0 */)
 {
+
+    DEBUG("Getting parent data of type " << std::to_string(kind_tree[array_indexes]));
 
     if (array_indexes == members_tree.size() - 1)
     {
@@ -285,7 +287,7 @@ DynamicData_ptr get_parent_data_of_member(
                 data->get_complex_value(&child_data, member_id);
 
                 return get_parent_data_of_member(
-                    DynamicData_ptr(child_data),
+                    child_data,
                     members_tree,
                     kind_tree,
                     array_indexes + 1);
@@ -306,11 +308,11 @@ DynamicData_ptr get_parent_data_of_member(
 }
 
 double get_numeric_type_from_data(
-        const DynamicData_ptr& data,
+        DynamicData* data,
         const MemberId& member,
         const TypeKind& kind)
 {
-    DEBUG("Getting numeric data of kind " << kind << " in member " << member);
+    DEBUG("Getting numeric data of kind " << std::to_string(kind) << " in member " << member);
 
     switch (kind)
     {
@@ -354,7 +356,7 @@ double get_numeric_type_from_data(
 }
 
 std::string get_string_type_from_data(
-        const DynamicData_ptr& data,
+        DynamicData* data,
         const MemberId& member,
         const TypeKind& kind)
 {

--- a/plugins/datastreamer_plugin/utils/dynamic_types_utils.hpp
+++ b/plugins/datastreamer_plugin/utils/dynamic_types_utils.hpp
@@ -65,7 +65,7 @@ std::vector<std::string> get_introspection_type_names(
  * If \c type is a basic type, it adds its label, that is \c base_type_name to the
  * \c TypeIntrospectionCollection that it belongs, depending if it is numeric or text kind.
  * Along with the label, it is added the vector of parents as member Ids and kinds.
- * Those are useful to allow to acces this specific field from a \c DynamicData_ptr .
+ * Those are useful to allow to acces this specific field from a \c DynamicData* .
  *
  * If \c type is not a basic type (array or struct) this function is called for each value
  * updating \c base_type_name for each recursive call.
@@ -110,7 +110,7 @@ void get_introspection_type_names(
  */
 void get_introspection_numeric_data(
         const TypeIntrospectionCollection& numeric_type_names,
-        const DynamicData_ptr& data,
+        DynamicData* data,
         TypeIntrospectionNumericStruct& numeric_data_result);
 
 /**
@@ -118,7 +118,7 @@ void get_introspection_numeric_data(
  */
 void get_introspection_string_data(
         const TypeIntrospectionCollection& string_type_names,
-        const DynamicData_ptr& data,
+        DynamicData* data,
         TypeIntrospectionStringStruct& string_data_result);
 
 /**
@@ -132,10 +132,10 @@ void get_introspection_string_data(
  * @param members_tree [in]
  * @param kind [in]
  * @param array_indexes [in]
- * @return DynamicData_ptr
+ * @return DynamicData*
  */
-DynamicData_ptr get_parent_data_of_member(
-        const DynamicData_ptr& data,
+DynamicData* get_parent_data_of_member(
+        DynamicData* data,
         const std::vector<MemberId>& members,
         const std::vector<TypeKind>& kinds,
         unsigned int array_index = 0);
@@ -149,7 +149,7 @@ DynamicData_ptr get_parent_data_of_member(
  * @return numeric data of the member casted to double
  */
 double get_numeric_type_from_data(
-        const DynamicData_ptr& data,
+        DynamicData* data,
         const MemberId& member,
         const TypeKind& kind);
 
@@ -162,7 +162,7 @@ double get_numeric_type_from_data(
  * @return string data of the member casted to string
  */
 std::string get_string_type_from_data(
-        const DynamicData_ptr& data,
+        DynamicData* data,
         const MemberId& member,
         const TypeKind& kind);
 


### PR DESCRIPTION
The plugin is breaking due to memory leaking when the dds message has arrays. This is related to the utilization of DynamicData_ptr and asynchronous deletion of data.
This is in some way related to the same problem of eProsima/Fast-DDS#2970

Signed-off-by: Douglas Bertol <dwbertol@gmail.com>