### PR TITLE
Add Key topic support

### DIFF
--- a/.dev/design/backend.plantuml
+++ b/.dev/design/backend.plantuml
@@ -1,0 +1,106 @@
+@startuml
+
+' ---------------------------------------------------------
+
+class FastDdsDataStreamer
+{
+    + on_double_data_read(<vector<NumericDatum>, double>)
+    + on_string_data_read(<vector<TextDatum>, double>)
+    + on_topic_discovery(<string, string, bool>)
+    # Backend::Handler fastdds_handler_
+}
+
+
+' ---------------------------------------------------------
+package Backend
+{
+
+class Handler
+{
+    + connect_to_domain(<int> domain_id)
+    + register_type_from_xml(<string> path)
+    + create_subscription(<string, DataTypeConfiguration>)
+    --
+    # clean_discovery_database()
+    __
+    # std::shared_ptr<TopicDataBase> discovery_database_
+    # std::unique_ptr<Participant> participant_
+    # FastDdsListener* listener_
+    # std::set<std::string> xml_data_types_paths_added_
+}
+
+class Participants
+{
+    + <bool> register_type_from_xml(<const std::string> path)
+    + create_subscription(<const std::string,const DataTypeConfiguration>)
+    + std::vector<types::DatumLabel> numeric_data_series_names()
+    + std::vector<types::DatumLabel> string_data_series_names ()
+    --
+    + on_publisher_discovery(<DomainParticipant, WriterDiscoveryInfo>)
+    + on_type_information_received(<DomainParticipant, string_255, string_255, TypeInformation>)
+    + on_type_discovery(<DomainParticipant, SampleIdentity, string_255, TypeIdentifier, Typoeobject, DynamicType_ptr>)
+    --
+    # on_topic_discovery(<string, string>)
+    __ Internal Variables  __
+    # std::shared_ptr<TopicDataBase> discovery_database_
+    # FastDdsListener* listener_;
+    __ Fast DDS pointers  __
+    # DomainParticipant* participant_
+    # Subscriber* subscriber_
+    # std::unordered_map<std::string, ReaderHandlerReference> readers_
+}
+
+class ReaderHandler
+{
+    + stop()
+    + on_data_available(<DataReader>)
+    --
+    __ Internal Variables __
+    __ Fast DDS pointers __
+    # Topic* topic_
+    # DataReader* reader_
+    # DynamicType_ptr type_
+    # DynamicData* data_
+    __
+    # std::atomic<bool> stop_
+    # TypeIntrospectionCollection numeric_data_info_
+    # TypeIntrospectionCollection string_data_info_
+    # TypeIntrospectionNumericStruct numeric_data_
+    # TypeIntrospectionStringStruct string_data_
+}
+
+interface FastDdsListener
+{
+    + {abstract} on_double_data_read(<vector<NumericDatum>, double>)
+    + {abstract} on_string_data_read(<vector<TextDatum>, double>)
+    + {abstract} on_topic_discovery(<string, string, bool>)
+}
+
+FastDdsDataStreamer <|-- FastDdsListener
+FastDdsDataStreamer *-- "1" Handler
+FastDdsDataStreamer *-- "1" Participants
+Handler "1" *-- Participants
+Participants "many" *-- ReaderHandler
+
+}
+
+' ---------------------------------------------------------
+
+package FastDDS
+{
+    class DomainParticipantListener
+    {
+        + {abstract} on_publisher_discovery(<DomainParticipant, WriterDiscoveryInfo>)
+        + {abstract} on_type_information_received(<DomainParticipant, string_255, string_255, TypeInformation>)
+        + {abstract} on_type_discovery(<DomainParticipant, SampleIdentity, string_255, TypeIdentifier, Typoeobject, DynamicType_ptr>)
+    }
+
+    class DataReaderListener
+    {
+        + {abstract} on_data_available(<DataReader>)
+    }
+
+    ReaderHandler <|-- DataReaderListener
+    Participants <|-- DomainParticipantListener
+}
+@enduml

--- a/.dev/sequences/dataReception.plantuml
+++ b/.dev/sequences/dataReception.plantuml
@@ -1,0 +1,148 @@
+@startuml
+' ---------------------------------------------------------
+
+
+box "FastDDS"
+
+participant DataReader
+participant DynamicDataFactory
+
+end box
+
+participant ReaderHandler
+participant FastDdsDataStreamer
+participant Handler
+participant Participant
+participant Plotjuggler
+entity utils
+
+' ---------------------------------------------------------
+
+DataReader -> ReaderHandler: on_data_available(DataReader* reader)
+activate ReaderHandler
+
+    ReaderHandler -> DynamicDataFactory: delete_data(data_)
+    ReaderHandler -> DynamicDataFactory: create_data()
+    activate DynamicDataFactory
+    DynamicDataFactory --> ReaderHandler: data_
+    deactivate DynamicDataFactory
+
+    loop data reading OK and continue
+        ReaderHandler -> DataReader: take_next_sample(&data_, &info)
+        activate DataReader
+        DataReader --> ReaderHandler: reading result
+        deactivate DataReader
+
+        ReaderHandler -> Plotjuggler: numeric_data_info_.clear()
+        ReaderHandler -> Plotjuggler: string_data_info_.clear()
+
+        ReaderHandler -> ReaderHandler: create_data_structures_(data_)
+        activate ReaderHandler
+
+            ReaderHandler -> ReaderHandler: serialize_data(_data)
+            ReaderHandler -> utils: get_formatted_data(topic_name, data_type_confguration_, numeric_data_info_, string_data_info_, serialized_data)
+            activate utils
+                note over utils 
+                This methods prepare numeric_data_info_ or string_data_info_ 
+                with data description and data itself (see type: TypeIntrospectionNumericStruct and TypeIntrospectionStringStruct) 
+                to be sent sent to plotjuggler through upper backend layers
+                end note
+            utils --> ReaderHandler
+            deactivate utils
+
+        ReaderHandler --> ReaderHandler
+        deactivate ReaderHandler
+
+        ReaderHandler -> FastDdsDataStreamer: on_data_available()
+        activate FastDdsDataStreamer
+
+            FastDdsDataStreamer -> FastDdsDataStreamer: create_series_()
+            activate FastDdsDataStreamer
+
+                FastDdsDataStreamer -> Handler: numeric_data_series_names
+                activate Handler
+
+                    Handler -> Participant: numeric_data_series_names
+                    activate Participant
+
+                    loop for reader in readers_
+                        Participant -> ReaderHandler: numeric_data_series_names
+                        activate ReaderHandler
+
+                        ReaderHandler --> Participant: vector<std::string names>
+                        deactivate ReaderHandler
+                    end
+
+                    Participant --> Handler: std::vector<types::DatumLabel (std::string)> numeric_series
+                    deactivate Participant
+
+                Handler --> FastDdsDataStreamer: numeric_series
+                deactivate Handler
+
+                FastDdsDataStreamer -> FastDdsDataStreamer: addNumeric(numeric_series)
+
+                FastDdsDataStreamer -> Handler: string_data_series_names
+                activate Handler
+
+                    Handler -> Participant: string_data_series_names
+                    activate Participant
+
+                    loop for reader in readers_
+                        Participant -> ReaderHandler: string_data_series_names
+                        activate ReaderHandler
+
+                        ReaderHandler --> Participant: vector<std::string names>
+                        deactivate ReaderHandler
+                    end
+
+                    Participant --> Handler: std::vector<types::DatumLabel (std::string)> string_series
+                    deactivate Participant
+
+                Handler --> FastDdsDataStreamer: string_series
+                deactivate Handler
+
+                FastDdsDataStreamer -> FastDdsDataStreamer: addStringSeries(numeric_series)
+
+            FastDdsDataStreamer --> FastDdsDataStreamer
+            deactivate FastDdsDataStreamer
+
+        FastDdsDataStreamer --> ReaderHandler
+        deactivate FastDdsDataStreamer
+
+        alt numeric_data not empty
+            ReaderHandler -> FastDdsDataStreamer: on_double_data_read(numeric_data_info_, timestamp)
+            activate FastDdsDataStreamer
+
+            note over FastDdsDataStreamer
+            Save data into fastDdsDataStreamer internal series and then emit a signal to PLotjuggler
+            for data to be plotted
+            end note
+            
+            FastDdsDataStreamer->PLotjuggler: emit dataReceived()
+
+            FastDdsDataStreamer --> ReaderHandler
+            deactivate FastDdsDataStreamer
+        end
+
+        alt string_data not empty
+            ReaderHandler -> FastDdsDataStreamer
+            ReaderHandler -> FastDdsDataStreamer: on_string_data_read(numeric_data_info_, timestamp)
+            activate FastDdsDataStreamer
+
+            note over FastDdsDataStreamer
+            Save data into fastDdsDataStreamer internal series and then emit a signal to PLotjuggler
+            for data to be plotted
+            end note
+
+            FastDdsDataStreamer->PLotjuggler: emit dataReceived()
+
+            FastDdsDataStreamer --> ReaderHandler
+            deactivate FastDdsDataStreamer
+        end
+
+
+    end 
+
+ReaderHandler --> DataReader
+deactivate ReaderHandler
+@enduml

--- a/.dev/sequences/onStart.plantuml
+++ b/.dev/sequences/onStart.plantuml
@@ -1,0 +1,139 @@
+@startuml
+
+' ---------------------------------------------------------
+actor plotjuggler
+participant FastDdsDataStreamer
+participant Handler
+participant Participant
+participant ReaderHandler
+
+box "FastDDS"
+participant DomainParticipantFactory
+participant DynamicPubSubType
+participant DomainParticipant
+participant Subscriber
+end box
+
+' ---------------------------------------------------------
+
+plotjuggler -> FastDdsDataStreamer: start
+activate FastDdsDataStreamer
+
+FastDdsDataStreamer -> FastDdsDataStreamer: connect_to_domain_
+activate FastDdsDataStreamer
+
+    FastDdsDataStreamer -> Handler: connect_to_domain(domain_id)
+    activate Handler
+
+    Handler -> Participant**: create
+    Participant -> DomainParticipant**: create
+    Participant -> Subscriber**: create
+
+    Handler --> FastDdsDataStreamer
+    deactivate Handler
+
+FastDdsDataStreamer --> FastDdsDataStreamer
+deactivate FastDdsDataStreamer
+
+FastDdsDataStreamer -> FastDdsDataStreamer: read user configuration
+
+loop selected_topics
+    FastDdsDataStreamer -> Handler: create_subscription
+    activate Handler
+
+        Handler -> Participant: create_subscription(topic_name, data_type_configuration)
+        activate Participant
+
+        Participant -> Participant: check if topic is registered
+        Participant -> Participant: check if type is registered
+
+        alt type is registered
+            Participant -> DomainParticipantFactory: get_dynamic_type()
+            activate DomainParticipantFactory
+
+            DomainParticipantFactory --> Participant: dyn_type
+            deactivate DomainParticipantFactory
+        else type not registered
+            Participant -> DynamicPubSubType** : new
+            Participant -> DynamicPubSubType: register_type(participant_)
+            activate DynamicPubSubType
+            DynamicPubSubType --> Participant
+            deactivate DynamicPubSubType
+        end
+
+        Participant -> DomainParticipant: create_topic(topic_name, type_name, default_topic_qos)
+        activate DomainParticipant
+
+        DomainParticipant --> Participant: topic*
+        deactivate DomainParticipant
+
+        Participant -> Subscriber: create_datareader(topic, default_datareader_qos_, this)
+        activate Subscriber
+
+        Subscriber --> Participant: datareader*
+        deactivate Subscriber
+
+        Participant -> ReaderHandler**: create(topic, datareader, dyn_type, ...)
+        Participant -> Participant: insert created reader into readers_
+
+        Participant --> Handler
+        deactivate Participant
+
+    Handler --> FastDdsDataStreamer
+    deactivate Handler
+end
+note across: Series creation also happen during runtime with:\non_data_available() methods that is called uppon data reception
+
+FastDdsDataStreamer -> FastDdsDataStreamer: create_series_
+activate FastDdsDataStreamer
+
+    FastDdsDataStreamer -> Handler: numeric_data_series_names
+    activate Handler
+
+        Handler -> Participant: numeric_data_series_names
+        activate Participant
+
+        loop for reader in readers_
+            Participant -> ReaderHandler: numeric_data_series_names
+            activate ReaderHandler
+
+            ReaderHandler --> Participant: vector<std::string names>
+            deactivate ReaderHandler
+        end
+
+        Participant --> Handler: std::vector<types::DatumLabel (std::string)> numeric_series
+        deactivate Participant
+
+    Handler --> FastDdsDataStreamer: numeric_series
+    deactivate Handler
+
+    FastDdsDataStreamer -> FastDdsDataStreamer: addNumeric(numeric_series)
+
+    FastDdsDataStreamer -> Handler: string_data_series_names
+    activate Handler
+
+        Handler -> Participant: string_data_series_names
+        activate Participant
+
+        loop for reader in readers_
+            Participant -> ReaderHandler: string_data_series_names
+            activate ReaderHandler
+
+            ReaderHandler --> Participant: vector<std::string names>
+            deactivate ReaderHandler
+        end
+
+        Participant --> Handler: std::vector<types::DatumLabel (std::string)> string_series
+        deactivate Participant
+
+    Handler --> FastDdsDataStreamer: string_series
+    deactivate Handler
+
+    FastDdsDataStreamer -> FastDdsDataStreamer: addStringSeries(numeric_series)
+FastDdsDataStreamer --> FastDdsDataStreamer
+deactivate FastDdsDataStreamer
+
+FastDdsDataStreamer --> plotjuggler: true
+deactivate FastDdsDataStreamer
+
+@enduml

--- a/.dev/sequences/onStart.plantuml
+++ b/.dev/sequences/onStart.plantuml
@@ -11,6 +11,8 @@ box "FastDDS"
 participant DomainParticipantFactory
 participant DynamicPubSubType
 participant DomainParticipant
+participant XMLProfileManager
+participant DynamicDataFactory
 participant Subscriber
 end box
 
@@ -54,26 +56,55 @@ loop selected_topics
             DomainParticipantFactory --> Participant: dyn_type
             deactivate DomainParticipantFactory
         else type not registered
-            Participant -> DynamicPubSubType** : new
+            Participant -> DomainParticipantFactory : newDynamicType
+            activate DomainParticipantFactory
+
+            DomainParticipantFactory --> Participant
+            deactivate DomainParticipantFactory
+
             Participant -> DynamicPubSubType: register_type(participant_)
             activate DynamicPubSubType
-            DynamicPubSubType --> Participant
+            DynamicPubSubType --> Participant: dyn_type
             deactivate DynamicPubSubType
         end
 
-        Participant -> DomainParticipant: create_topic(topic_name, type_name, default_topic_qos)
+        Participant -> DynamicPubSubType: dyn_type->m_isGetKeyDefined
+        activate DynamicPubSubType
+
+        DynamicPubSubType --> Participant: is_keyed
+        deactivate DynamicPubSubType
+        
+        alt is_keyed is true
+            Participant -> Participant: topic_qos = key_topic_qos_()
+            Participant -> Participant: reader_qos = key_datareader_qos_()
+        else
+            Participant -> Participant: topic_qos = default_topic_qos_()
+            Participant -> Participant: reader_qos = default_datareader_qos_()
+        end
+
+        Participant -> DomainParticipant: create_topic(topic_name, type_name, topic_qos)
         activate DomainParticipant
 
         DomainParticipant --> Participant: topic*
         deactivate DomainParticipant
 
-        Participant -> Subscriber: create_datareader(topic, default_datareader_qos_, this)
+        Participant -> Subscriber: create_datareader(topic, reader_qos, this)
         activate Subscriber
 
         Subscriber --> Participant: datareader*
         deactivate Subscriber
 
-        Participant -> ReaderHandler**: create(topic, datareader, dyn_type, ...)
+        Participant -> ReaderHandler**: create(topic, datareader, dyn_type, ..., is_keyed)
+        activate ReaderHandler
+
+            ReaderHandler -> DynamicDataFactory: create_data(type_)
+            activate DynamicDataFactory
+
+            DynamicDataFactory -> ReaderHandler: data_
+            deactivate DynamicDataFactory
+
+        deactivate ReaderHandler
+
         Participant -> Participant: insert created reader into readers_
 
         Participant --> Handler
@@ -82,56 +113,6 @@ loop selected_topics
     Handler --> FastDdsDataStreamer
     deactivate Handler
 end
-note across: Series creation also happen during runtime with:\non_data_available() methods that is called uppon data reception
-
-FastDdsDataStreamer -> FastDdsDataStreamer: create_series_
-activate FastDdsDataStreamer
-
-    FastDdsDataStreamer -> Handler: numeric_data_series_names
-    activate Handler
-
-        Handler -> Participant: numeric_data_series_names
-        activate Participant
-
-        loop for reader in readers_
-            Participant -> ReaderHandler: numeric_data_series_names
-            activate ReaderHandler
-
-            ReaderHandler --> Participant: vector<std::string names>
-            deactivate ReaderHandler
-        end
-
-        Participant --> Handler: std::vector<types::DatumLabel (std::string)> numeric_series
-        deactivate Participant
-
-    Handler --> FastDdsDataStreamer: numeric_series
-    deactivate Handler
-
-    FastDdsDataStreamer -> FastDdsDataStreamer: addNumeric(numeric_series)
-
-    FastDdsDataStreamer -> Handler: string_data_series_names
-    activate Handler
-
-        Handler -> Participant: string_data_series_names
-        activate Participant
-
-        loop for reader in readers_
-            Participant -> ReaderHandler: string_data_series_names
-            activate ReaderHandler
-
-            ReaderHandler --> Participant: vector<std::string names>
-            deactivate ReaderHandler
-        end
-
-        Participant --> Handler: std::vector<types::DatumLabel (std::string)> string_series
-        deactivate Participant
-
-    Handler --> FastDdsDataStreamer: string_series
-    deactivate Handler
-
-    FastDdsDataStreamer -> FastDdsDataStreamer: addStringSeries(numeric_series)
-FastDdsDataStreamer --> FastDdsDataStreamer
-deactivate FastDdsDataStreamer
 
 FastDdsDataStreamer --> plotjuggler: true
 deactivate FastDdsDataStreamer


### PR DESCRIPTION
This PR add key annotation support for fastdds-visualizer-plugin.

To be done before draft status can be removed:

- [x] Document future changes in .dev (based on a trial and error branch)
- [ ] Update startup sequence
- [ ] Update data reception

Please note that in order to use documentation, I have rebased this branch on documentation one referenced in this PR: #67 

closes #56 