### PR TITLE
Add Discovery Server setting in the UI

### DIFF
--- a/plugins/datastreamer_plugin/datastreamer/FastDdsDataStreamer.cpp
+++ b/plugins/datastreamer_plugin/datastreamer/FastDdsDataStreamer.cpp
@@ -242,6 +242,13 @@ void FastDdsDataStreamer::on_domain_connection(
     connect_to_domain_(domain_id);
 }
 
+void FastDdsDataStreamer::on_server_connection(
+        unsigned int domain_id, const std::string& server_ip, unsigned int server_port)
+{
+    DEBUG("FastDdsDataStreamer on_domain_connection " << domain_id);
+    connect_to_server_(domain_id, server_ip, server_port);
+}
+
 ////////////////////////////////////////////////////
 // AUXILIAR METHODS
 ////////////////////////////////////////////////////
@@ -258,6 +265,19 @@ void FastDdsDataStreamer::connect_to_domain_(
     // Connect to domain
     fastdds_handler_.connect_to_domain(domain_id);
     select_topics_dialog_.connect_to_domain(domain_id);
+}
+
+void FastDdsDataStreamer::connect_to_server_(
+        unsigned int domain_id, const std::string& server_ip, unsigned int server_port)
+{
+    DEBUG("FastDdsDataStreamer connect_to_server_ " << server_ip<<":"<<server_port<<" using domain "<<domain_id);
+    // Reset view and handler
+    select_topics_dialog_.reset();
+    fastdds_handler_.reset();
+
+    // Connect to domain
+    fastdds_handler_.connect_to_server(domain_id, server_ip, server_port);
+    select_topics_dialog_.connect_to_server(domain_id, server_ip, server_port);
 }
 
 void FastDdsDataStreamer::create_series_()

--- a/plugins/datastreamer_plugin/datastreamer/FastDdsDataStreamer.hpp
+++ b/plugins/datastreamer_plugin/datastreamer/FastDdsDataStreamer.hpp
@@ -116,6 +116,8 @@ public:
     virtual void on_domain_connection(
             unsigned int domain_id) override;
 
+    virtual void on_server_connection(
+        unsigned int domain_id, const std::string& server_ip, unsigned int server_port);
 
     ////////////////////////////////////////////////////
     // STATIC METHODS AND PUBLIC MEMBERS
@@ -131,6 +133,9 @@ protected:
 
     void connect_to_domain_(
             unsigned int domain_id);
+
+   void connect_to_server_(
+        unsigned int domain_id, const std::string& server_ip, unsigned int server_port);
 
     void create_series_();
 

--- a/plugins/datastreamer_plugin/fastdds/Handler.cpp
+++ b/plugins/datastreamer_plugin/fastdds/Handler.cpp
@@ -62,6 +62,16 @@ void Handler::connect_to_domain(
     participant_ = std::make_unique<Participant>(domain, discovery_database_, listener_);
 }
 
+void Handler::connect_to_server(
+        const uint32_t domain, const std::string& server_ip, unsigned int server_port)
+{
+    // Reset in case a Handler exist
+    reset();
+
+    // Create participant using discovery server
+    participant_ = std::make_unique<Participant>(domain, discovery_database_, listener_, true, server_ip, server_port);
+}
+
 void Handler::register_type_from_xml(
         const std::string& xml_path)
 {

--- a/plugins/datastreamer_plugin/fastdds/Handler.hpp
+++ b/plugins/datastreamer_plugin/fastdds/Handler.hpp
@@ -67,6 +67,9 @@ public:
     void connect_to_domain(
             const uint32_t domain);
 
+    void connect_to_server(
+        const uint32_t domain, const std::string& server_ip, unsigned int server_port);
+
     void register_type_from_xml(
             const std::string& xml_path);
 

--- a/plugins/datastreamer_plugin/fastdds/Participant.hpp
+++ b/plugins/datastreamer_plugin/fastdds/Participant.hpp
@@ -86,7 +86,10 @@ public:
     Participant(
             eprosima::fastdds::dds::DomainId_t domain_id,
             std::shared_ptr<TopicDataBase> discovery_database,
-            FastDdsListener* listener);
+            FastDdsListener* listener,
+            bool use_discovery_server = false,
+            const std::string& server_ip = "127.0.0.1",
+            const unsigned int& server_port = 11811);
 
     virtual ~Participant();
 

--- a/plugins/datastreamer_plugin/ui/topic_selection_dialog/Configuration.cpp
+++ b/plugins/datastreamer_plugin/ui/topic_selection_dialog/Configuration.cpp
@@ -87,6 +87,8 @@ void Configuration::save_default_settings(
     settings.setValue(prefix + DISCARD_LARGE_ARRAYS_SETTINGS_TAG, data_type_configuration.discard_large_arrays);
     settings.setValue(prefix + XML_DATATYPE_FILES_SETTINGS_TAG, xml_datatypes_files);
     settings.setValue(prefix + DOMAIN_ID_SETTINGS_TAG, domain_id);
+    settings.setValue(prefix + SERVER_IP_SETTINGS_TAG, server_ip.c_str());
+    settings.setValue(prefix + SERVER_PORT_SETTINGS_TAG, server_port);
 }
 
 void Configuration::load_default_settings(
@@ -103,6 +105,8 @@ void Configuration::load_default_settings(
                     data_type_configuration.discard_large_arrays).toBool();
     xml_datatypes_files = settings.value(prefix + XML_DATATYPE_FILES_SETTINGS_TAG, xml_datatypes_files).toStringList();
     domain_id = settings.value(prefix + DOMAIN_ID_SETTINGS_TAG, domain_id).toInt();
+    server_ip = settings.value(prefix + SERVER_IP_SETTINGS_TAG, server_ip.c_str()).toString().toStdString();
+    server_port = settings.value(prefix + SERVER_PORT_SETTINGS_TAG, server_port).toUInt();
 }
 
 } /* namespace ui */

--- a/plugins/datastreamer_plugin/ui/topic_selection_dialog/Configuration.hpp
+++ b/plugins/datastreamer_plugin/ui/topic_selection_dialog/Configuration.hpp
@@ -61,6 +61,9 @@ struct Configuration
     // DDS Configuration
     unsigned int domain_id = 0;
     QStringList xml_datatypes_files;  // Empty in initialization
+    // Discovery server configuration
+    std::string server_ip = "127.0.0.1";
+    unsigned int server_port = 11811;
 
     ////////////////////
     // Advance options
@@ -87,6 +90,8 @@ protected:
     constexpr static const char* DISCARD_LARGE_ARRAYS_SETTINGS_TAG = "discard_large_arrays";
     constexpr static const char* XML_DATATYPE_FILES_SETTINGS_TAG = "xml_datatype_files";
     constexpr static const char* DOMAIN_ID_SETTINGS_TAG = "domain_id_files";
+    constexpr static const char* SERVER_IP_SETTINGS_TAG = "server_ip_files";
+    constexpr static const char* SERVER_PORT_SETTINGS_TAG = "server_port_files";
 };
 
 

--- a/plugins/datastreamer_plugin/ui/topic_selection_dialog/UiListener.hpp
+++ b/plugins/datastreamer_plugin/ui/topic_selection_dialog/UiListener.hpp
@@ -51,6 +51,13 @@ public:
         static_cast<void>(domain_id);
     }
 
+    virtual void on_server_connection(
+        unsigned int domain_id, const std::string& server_ip, unsigned int server_port){
+        DEBUG("Calling on_server_connection " << domain_id << " " << server_ip << " " << server_port);
+        static_cast<void>(domain_id);
+        static_cast<void>(server_ip);
+        static_cast<void>(server_port);
+    }
 };
 
 } /* namespace ui */

--- a/plugins/datastreamer_plugin/ui/topic_selection_dialog/dialogselecttopics.h
+++ b/plugins/datastreamer_plugin/ui/topic_selection_dialog/dialogselecttopics.h
@@ -64,6 +64,10 @@ public:
     void connect_to_domain(
             const uint32_t domain_id);
 
+    void connect_to_server(
+                const uint32_t domain_id,
+                const std::string& server_ip,
+                unsigned int server_port);
 signals:
 
     void reset_view_signal();
@@ -76,6 +80,11 @@ signals:
     void connection_to_domain_signal(
             const uint32_t domain_id);
 
+   void connection_to_server_signal(
+        const uint32_t domain_id,
+        const QString& server_ip,
+        const uint32_t server_port);
+
 private slots:
 
     void on_lineEditFilter_textChanged(
@@ -85,6 +94,8 @@ private slots:
             int arg1);
 
     void on_change_domain_button_clicked();
+
+    void on_use_discovery_server_button_clicked();
 
     void on_include_files_button_clicked();
 
@@ -105,6 +116,11 @@ private slots:
 
     void on_connectionToDomain(
             const uint32_t domain_id);
+
+    void on_connectionToServer(
+            const uint32_t domain_id,
+            const QString& server_ip,
+            unsigned int server_port);
 
 protected:
 
@@ -149,6 +165,9 @@ protected:
     constexpr static const unsigned int TypeNameTableIndex_ = 1;
 
     unsigned int domain_id_connected_;
+    //! Variables storing discovery server information
+    std::string server_ip_;
+    unsigned int server_port_;
 
     QShortcut select_all_topics_;
     QShortcut deselect_all_topics_;

--- a/plugins/datastreamer_plugin/ui/topic_selection_dialog/dialogselecttopics.ui
+++ b/plugins/datastreamer_plugin/ui/topic_selection_dialog/dialogselecttopics.ui
@@ -336,6 +336,139 @@
           </layout>
          </item>
          <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_8">
+           <item>
+            <widget class="QLabel" name="label_10">
+             <property name="text">
+              <string>Use Server Discovery </string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_10">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Preferred</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>35</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="use_discovery_server_button">
+             <property name="text">
+                <string>OFF</string>
+             </property>
+             <property name="checkable">
+                <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_11">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_11">
+             <property name="text">
+              <string>server IP: </string>
+             </property>
+            </widget>
+           </item>
+            <item>
+                <widget class="QLineEdit" name="server_ip">
+                <property name="maxLength">
+                <number>15</number>
+                </property>
+                <property name="text">
+                    <string>127.0.0.1</string>  <!-- Default server IP address -->
+                </property>
+                <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                    </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                        <size>
+                            <width>100</width>
+                            <height>25</height>
+                        </size>
+                    </property>
+                    <property name="maximumSize">
+                        <size>
+                            <width>120</width>
+                            <height>30</height>
+                        </size>
+                    </property>
+                </widget>
+            </item>
+            <item>
+            <widget class="QLabel" name="label_12">
+             <property name="text">
+              <string>server port: </string>
+             </property>
+            </widget>
+           </item>
+            <item>
+                <widget class="QLineEdit" name="server_port">
+                <property name="maxLength">
+                <number>15</number>
+                </property>
+                <property name="text">
+                    <string>11811</string>  <!-- Default server port -->
+                </property>
+                <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                    </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                        <size>
+                            <width>40</width>
+                            <height>25</height>
+                        </size>
+                    </property>
+                    <property name="maximumSize">
+                        <size>
+                            <width>80</width>
+                            <height>30</height>
+                        </size>
+                    </property>
+                </widget>
+            </item>
+            <item>
+                <spacer name="horizontalSpacer_12">
+                    <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeHint">
+                        <size>
+                            <width>120</width>
+                            <height>2</height>
+                        </size>
+                    </property>
+                </spacer>
+            </item>
+          </layout>
+         </item>
+         <item>
           <widget class="Line" name="line_3">
            <property name="frameShadow">
             <enum>QFrame::Sunken</enum>

--- a/plugins/datastreamer_plugin/ui/topic_selection_dialog/dialogselecttopics.ui
+++ b/plugins/datastreamer_plugin/ui/topic_selection_dialog/dialogselecttopics.ui
@@ -340,7 +340,7 @@
            <item>
             <widget class="QLabel" name="label_10">
              <property name="text">
-              <string>Use Server Discovery </string>
+              <string>Use Discovery Server </string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
This PR adds the possibility to discover and visualize topics in Plotjuggler when using [Discovery Server](https://fast-dds.docs.eprosima.com/en/latest/fastdds/discovery/discovery_server.html#discovery-server) setting.

The UI has been changed as follows

![Screenshot from 2025-01-24 12-44-20](https://github.com/user-attachments/assets/ad603ee0-ac87-4b2e-a79c-7fb8c2b0cc89)

# How to use
As in the current behavior, when the _Select DDS message_ window appears, by default a domain participant in the _Current DomainId_ domain is created, which uses Simple Discovery.

To allow Plotjuggler to discover topics when using Discovery Server setting you need to:

- set the server ip in the  _server IP_ field
- set the server port in the _server port_ field
- enable the Discovery Server setting by clicking on the button _OFF_

Once the Discovery Server setting is enable, you will see: 

- the button changing to _ON_
- the _Change Domain_ button becoming gray, meaning that when the Discovery Server setting is _ON_ you cannot use _Simple Discovery_, avoiding to mix incompatible discovery settings

![Screenshot from 2025-01-24 12-44-58](https://github.com/user-attachments/assets/dccf92ce-ba6c-4c2a-8a17-13bd1d45f36d)

When the Discovery Server setting is turned off by clicking the _ON_ button, a domain participant is created in the _Current DomainId_ domain using Simple Discovery and the possibility use Simple Discovery and to change the domain is restored.

Notice that _server IP_ and _server port_ need to be set **before** starting the discovery server, so when the button is in _OFF_ state.