### PR TITLE
Set TopicDataType name before registering types in DomainParticipant

### DIFF
--- a/plugins/datastreamer_plugin/datastreamer/FastDdsDataStreamer.cpp
+++ b/plugins/datastreamer_plugin/datastreamer/FastDdsDataStreamer.cpp
@@ -213,10 +213,6 @@ void FastDdsDataStreamer::on_topic_discovery(
     DEBUG("FastDdsDataStreamer topic_discovery_signal " << topic_name);
     bool type_info_available = fastdds_handler_.get_topic_data_base()->operator [](topic_name).second;
 
-    // __FLAG__
-    DEBUG("topic discovery signal with type name " << type_name << " and type info available " << type_info_available);
-    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
     // Emit signal to UI so it is handled from Qt thread
     emit select_topics_dialog_.topic_discovery_signal(
         utils::string_to_QString(topic_name),

--- a/plugins/datastreamer_plugin/fastdds/Participant.cpp
+++ b/plugins/datastreamer_plugin/fastdds/Participant.cpp
@@ -183,9 +183,7 @@ void Participant::create_subscription(
     // Check if type is registered or not in participant. If not, register it
     if (!participant_->find_type(type_name))
     {
-        // __FLAG__
         DEBUG("Type info not registered in participant for topic " << topic_name);
-        //////////////////////////
 
         // Type information is available but not registered in participant
         // Types manually loaded (through XML file) are registered in participant when loaded, so this case is not possible
@@ -204,6 +202,7 @@ void Participant::create_subscription(
         dyn_type = DynamicTypeBuilderFactory::get_instance()->create_type_w_type_object(
             type_object)->build();
         TypeSupport dyn_type_support(new DynamicPubSubType(dyn_type));
+        dyn_type_support->set_name(type_name);
         dyn_type_support.register_type(participant_);
     }
     else
@@ -307,9 +306,7 @@ void Participant::on_data_writer_discovery(
 
         if (!info.type_information.assigned())
         {
-            // __FLAG__
             DEBUG("Type information not assigned for topic " << topic_name);
-            /////////////////////////////
             // If type info is not assigned, check if it can be generated through a xml
             on_topic_discovery_(topic_name, type_name);
         }
@@ -360,9 +357,7 @@ void Participant::on_topic_discovery_(
         const DataTypeId& type_id)
 {
     // TODO: check if mutex required
-    // __FLAG__
     DEBUG("Calling on_topic_discovery with type id for topic " << topic_name);
-    /////////////////
     bool is_already_discovered = false;
 
     // Check if this topic has already been discovered
@@ -380,15 +375,9 @@ void Participant::on_topic_discovery_(
     if (!is_already_discovered)
     {
         // Add topic as discovered and save its type name and its type identifier to build DynamicType when DataReader is created
-        // __FLAG__
         DEBUG("Topic " << topic_name << " discovered with type id");
-        DEBUG("Updating databases...");
-        DEBUG("...Updating discovery database...");
         discovery_database_->operator [](topic_name) = {type_name, true};
-        DEBUG("...Updating dynamic types info database...");
         dyn_types_info_->operator [](topic_name) = {type_name, type_id};
-        DEBUG("...Databases updated");
-        /////////////////////////////////////////////
     }
 
     // Call listener callback to notify new topic

--- a/plugins/datastreamer_plugin/fastdds/Participant.cpp
+++ b/plugins/datastreamer_plugin/fastdds/Participant.cpp
@@ -173,10 +173,10 @@ void Participant::create_subscription(
     DataTypeNameType type_name = discovery_database_->operator [](topic_name).first;
     DynamicType::_ref_type dyn_type;
 
-    // Check if type is already registered
+    // Check if type info is available
     if (discovery_database_->operator [](topic_name).second == false)
     {
-        WARNING("Type " << topic_name << " has not been registered yet");
+        WARNING("Type " << topic_name << ": info not available yet");
         throw InconsistencyException("Trying to create Data Reader in a non registered type: " + topic_name);
     }
 


### PR DESCRIPTION
This PR solves an issue reported in https://github.com/eProsima/Fast-DDS-python/issues/222.

If the user sets the type name manually using `TopicDataType::set_name(type_name_A)`, an error happens when trying to create the topic in the Plotjuggler side Participant.

 On the Publisher side, the `TypeObject` that is registered in the `TypeObjectRegistry` is built with a  type name `type_name_B`, hardcoded in the code generated by Fast DDS Gen.

On the PlotJuggler side, the Participant reconstructs the `TypeSupport` from the registered `TypeObject`, so `TypeSupport->get_name()` returns `type_name_B` instead of `type_name_A`, which is received an stored internally through the `on_data_writer_discovery` callback implementation. Therefore, the Participant registers the type with the name `type_name_B`, while the topic is attempted to be created with type name `type_name_A`, causing an error. 

There are two possible solutions to fix the problem:

1. Use `DomainParticipant` API to register the type with `type_name_A`.
2. Set `TypeSupport` type name to the type name discovered using `TypeSupport->set_name(type_name_A)` before registering the type.

This PR uses the second approach.